### PR TITLE
add get api/review/:review_id with error handling

### DIFF
--- a/__tests__/endpoints.test.js
+++ b/__tests__/endpoints.test.js
@@ -18,7 +18,6 @@ describe("GET /api/categoriess", () => {
       .get("/api/categoriess")
       .expect(404)
       .then(({ body }) => {
-        console.log(body);
         expect(body.msg).toBe("Path not found");
       });
   });
@@ -38,6 +37,47 @@ describe("GET /api/categories", () => {
             description: expect(String),
           });
         });
+      });
+  });
+});
+
+describe("GET /api/reviews/:review_id", () => {
+  const expectedProperties = [
+    "review_id",
+    "title",
+    "category",
+    "designer",
+    "owner",
+    "review_body",
+    "review_img_url",
+    "created_at",
+    "votes",
+  ];
+  it("Returns a review object, with following properties, review_id, title, review_body, designer, review_img_url, votes, category field , owner and created_at", () => {
+    return request(app)
+      .get("/api/reviews/4")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body).toBeInstanceOf(Object);
+        expect(body.review_id).toBe(4);
+        const resultKeys = Object.keys(body);
+        expect(resultKeys).toEqual(expectedProperties);
+      });
+  });
+  it("Returns an error message if the id is not present (Out of range)", () => {
+    return request(app)
+      .get("/api/reviews/4444")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("ID out of range");
+      });
+  });
+  it("Returns an error message if the id is not present (Out of range)", () => {
+    return request(app)
+      .get("/api/reviews/four")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Invalid ID, Please use a number");
       });
   });
 });

--- a/__tests__/endpoints.test.js
+++ b/__tests__/endpoints.test.js
@@ -67,17 +67,17 @@ describe("GET /api/reviews/:review_id", () => {
   it("Returns an error message if the id is not present (Out of range)", () => {
     return request(app)
       .get("/api/reviews/4444")
-      .expect(400)
+      .expect(404)
       .then(({ body }) => {
-        expect(body.msg).toBe("ID out of range");
+        expect(body.msg).toBe("ID not found");
       });
   });
   it("Returns an error message if the id is not present (Out of range)", () => {
     return request(app)
       .get("/api/reviews/four")
-      .expect(400)
+      .expect(404)
       .then(({ body }) => {
-        expect(body.msg).toBe("Invalid ID, Please use a number");
+        expect(body.msg).toBe("Invalid ID");
       });
   });
 });

--- a/app/app.js
+++ b/app/app.js
@@ -1,22 +1,23 @@
 const express = require("express");
 const app = express();
+const { getCategories, getReviewId } = require("../controllers/controllers.js");
+const {
+  PSQLError,
+  customError,
+  internalError,
+} = require("./error-handling.js");
 
-//requiring controller variables
-const { getCategories } = require("../controllers/controllers.js");
-
-//endpoints
 app.get("/api/categories", getCategories);
+app.get("/api/reviews/:review_id", getReviewId);
 
 app.get("/*", (req, res) => {
   res.status(404).send({ msg: "Path not found" });
 });
 
-//custom error handling
+app.use(PSQLError);
 
-//default SQL error handling using error codes
+app.use(customError);
 
-app.use((err, req, res, next) => {
-  res.status(500).send({ msg: "Internal Server Error" });
-});
+app.use(internalError);
 
 module.exports = app;

--- a/app/error-handling.js
+++ b/app/error-handling.js
@@ -1,0 +1,17 @@
+const PSQLError = (err, req, res, next) => {
+  if (err.code === "22P02") {
+    res.status(400).send({ msg: "Invalid ID, Please use a number" });
+  } else next(err);
+};
+
+const customError = (err, req, res, next) => {
+  if (err.status && err.msg) {
+    res.status(err.status).send({ msg: err.msg });
+  } else next(err);
+};
+
+const internalError = (err, req, res, next) => {
+  res.status(500).send({ msg: "Internal Server Error" });
+};
+
+module.exports = { PSQLError, customError, internalError };

--- a/app/error-handling.js
+++ b/app/error-handling.js
@@ -1,6 +1,6 @@
 const PSQLError = (err, req, res, next) => {
   if (err.code === "22P02") {
-    res.status(400).send({ msg: "Invalid ID, Please use a number" });
+    res.status(404).send({ msg: "Invalid ID" });
   } else next(err);
 };
 

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -1,11 +1,20 @@
-const { fetchCategories } = require("../models/models.js");
+const { fetchCategories, fetchReviewId } = require("../models/models.js");
 
-const getCategories = (req, res) => {
+const getCategories = (req, res, next) => {
   fetchCategories()
     .then((categories) => {
       res.status(200).send(categories);
     })
-    .catch((err) => next(err));
+    .catch(next);
 };
 
-module.exports = { getCategories };
+const getReviewId = (req, res, next) => {
+  const id = req.params.review_id;
+  fetchReviewId(id)
+    .then((review) => {
+      res.status(200).send(review);
+    })
+    .catch(next);
+};
+
+module.exports = { getCategories, getReviewId };

--- a/models/models.js
+++ b/models/models.js
@@ -6,4 +6,15 @@ const fetchCategories = () => {
   });
 };
 
-module.exports = { fetchCategories };
+const fetchReviewId = (id) => {
+  return db
+    .query(`SELECT * FROM reviews WHERE review_id = $1;`, [id])
+    .then(({ rows }) => {
+      if (rows.length === 0) {
+        return Promise.reject({ status: 400, msg: "ID out of range" });
+      }
+      return rows[0];
+    });
+};
+
+module.exports = { fetchCategories, fetchReviewId };

--- a/models/models.js
+++ b/models/models.js
@@ -11,7 +11,7 @@ const fetchReviewId = (id) => {
     .query(`SELECT * FROM reviews WHERE review_id = $1;`, [id])
     .then(({ rows }) => {
       if (rows.length === 0) {
-        return Promise.reject({ status: 400, msg: "ID out of range" });
+        return Promise.reject({ status: 404, msg: "ID not found" });
       }
       return rows[0];
     });


### PR DESCRIPTION
This pull request adds a get request to parametric endpoint, api/review/:review_id, along with errors handled like ID out of range or of wrong datatype. Furthermore, app.js is made tidy by moving all the error handling functions into a separate file and subsequently exporting them.