### PR TITLE
add patch reviews with new votes with 5 different error handling

### DIFF
--- a/__tests__/endpoints.test.js
+++ b/__tests__/endpoints.test.js
@@ -77,7 +77,7 @@ describe("GET /api/reviews/:review_id", () => {
       .get("/api/reviews/four")
       .expect(404)
       .then(({ body }) => {
-        expect(body.msg).toBe("Invalid ID");
+        expect(body.msg).toBe("Invalid Request");
       });
   });
 });
@@ -97,6 +97,75 @@ describe("GET /api/users", () => {
             avatar_url: expect(String),
           });
         });
+      });
+  });
+});
+
+describe("PATCH /api/reviews/:review_id", () => {
+  it("PATCH /api/reviews/2 should update the voting count of that review", () => {
+    const newVotes = { inc_votes: 4 };
+    // const otherVotes = { inc_votes: -10 };
+    return request(app)
+      .patch("/api/reviews/2")
+      .send(newVotes)
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.votes).toBe(9);
+      });
+  });
+
+  it("PATCH /api/reviews/2 should update the voting count (negative) of that review", () => {
+    const otherVotes = { inc_votes: -10 };
+    return request(app)
+      .patch("/api/reviews/4")
+      .send(otherVotes)
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.votes).toBe(-3);
+      });
+  });
+
+  it("PATCH /api/reviews/223112 should respond with an error message and 404 error as the id does not exist", () => {
+    const otherVotes = { inc_votes: 10 };
+    return request(app)
+      .patch("/api/reviews/223112")
+      .send(otherVotes)
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Invalid ID");
+      });
+  });
+
+  it("PATCH /api/reviews/five should respond with an error message and 404 error as the id is not an integer", () => {
+    const otherVotes = { inc_votes: 10 };
+    return request(app)
+      .patch("/api/reviews/five")
+      .send(otherVotes)
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Invalid Request");
+      });
+  });
+
+  it("PATCH /api/reviews/5 with number of votes in the wrong format should respond with an error message as number of votes should be integer", () => {
+    const otherVotes = { inc_votes: "one" };
+    return request(app)
+      .patch("/api/reviews/5")
+      .send(otherVotes)
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Invalid Request");
+      });
+  });
+
+  it("PATCH /api/reviews/5 with key other than inc_votes should respond with an error message as number of votes should be integer", () => {
+    const otherVotes = { add_votes: 2 };
+    return request(app)
+      .patch("/api/reviews/5")
+      .send(otherVotes)
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Invalid update request");
       });
   });
 });

--- a/__tests__/endpoints.test.js
+++ b/__tests__/endpoints.test.js
@@ -75,7 +75,7 @@ describe("GET /api/reviews/:review_id", () => {
   it("Returns an error message if the id is not present (Out of range)", () => {
     return request(app)
       .get("/api/reviews/four")
-      .expect(404)
+      .expect(400)
       .then(({ body }) => {
         expect(body.msg).toBe("Invalid Request");
       });
@@ -141,7 +141,7 @@ describe("PATCH /api/reviews/:review_id", () => {
     return request(app)
       .patch("/api/reviews/five")
       .send(otherVotes)
-      .expect(404)
+      .expect(400)
       .then(({ body }) => {
         expect(body.msg).toBe("Invalid Request");
       });
@@ -152,7 +152,7 @@ describe("PATCH /api/reviews/:review_id", () => {
     return request(app)
       .patch("/api/reviews/5")
       .send(otherVotes)
-      .expect(404)
+      .expect(400)
       .then(({ body }) => {
         expect(body.msg).toBe("Invalid Request");
       });

--- a/app/app.js
+++ b/app/app.js
@@ -4,6 +4,7 @@ const {
   getCategories,
   getReviewId,
   getUsers,
+  updateReviewVotes,
 } = require("../controllers/controllers.js");
 const {
   PSQLError,
@@ -11,9 +12,12 @@ const {
   internalError,
 } = require("./error-handling.js");
 
+app.use(express.json());
+
 app.get("/api/categories", getCategories);
 app.get("/api/reviews/:review_id", getReviewId);
 app.get("/api/users", getUsers);
+app.patch("/api/reviews/:review_id", updateReviewVotes);
 
 app.get("/*", (req, res) => {
   res.status(404).send({ msg: "Path not found" });

--- a/app/error-handling.js
+++ b/app/error-handling.js
@@ -1,6 +1,6 @@
 const PSQLError = (err, req, res, next) => {
   if (err.code === "22P02") {
-    res.status(404).send({ msg: "Invalid Request" });
+    res.status(400).send({ msg: "Invalid Request" });
   } else next(err);
 };
 

--- a/app/error-handling.js
+++ b/app/error-handling.js
@@ -1,6 +1,6 @@
 const PSQLError = (err, req, res, next) => {
   if (err.code === "22P02") {
-    res.status(404).send({ msg: "Invalid ID" });
+    res.status(404).send({ msg: "Invalid Request" });
   } else next(err);
 };
 

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -2,6 +2,7 @@ const {
   fetchCategories,
   fetchReviewId,
   fetchUsers,
+  patchReviewVotes,
 } = require("../models/models.js");
 
 const getCategories = (req, res, next) => {
@@ -21,10 +22,20 @@ const getReviewId = (req, res, next) => {
     .catch(next);
 };
 
-const getUsers = (req, res, next) => {
+const getUsers = (req, res) => {
   fetchUsers().then((users) => {
     res.status(200).send(users);
   });
 };
 
-module.exports = { getCategories, getReviewId, getUsers };
+const updateReviewVotes = (req, res, next) => {
+  const voteBody = req.body;
+  const id = req.params.review_id;
+  patchReviewVotes(id, voteBody)
+    .then((updatedReview) => {
+      res.status(200).send(updatedReview);
+    })
+    .catch(next);
+};
+
+module.exports = { getCategories, getReviewId, getUsers, updateReviewVotes };

--- a/models/models.js
+++ b/models/models.js
@@ -22,9 +22,7 @@ const fetchUsers = () => {
 };
 
 const patchReviewVotes = (id, voteBody) => {
-  const theKey = Object.keys(voteBody);
-
-  if (theKey[0] !== "inc_votes") {
+  if (!voteBody.inc_votes) {
     return Promise.reject({ status: 400, msg: "Invalid update request" });
   }
 

--- a/models/models.js
+++ b/models/models.js
@@ -21,4 +21,31 @@ const fetchUsers = () => {
   return db.query(`SELECT * FROM users;`).then(({ rows }) => rows);
 };
 
-module.exports = { fetchCategories, fetchReviewId, fetchUsers };
+const patchReviewVotes = (id, voteBody) => {
+  const theKey = Object.keys(voteBody);
+
+  if (theKey[0] !== "inc_votes") {
+    return Promise.reject({ status: 400, msg: "Invalid update request" });
+  }
+
+  const newVotes = voteBody.inc_votes;
+
+  return db
+    .query(
+      `UPDATE reviews SET votes = votes + $2 WHERE review_id = $1 RETURNING *;`,
+      [id, newVotes]
+    )
+    .then(({ rows }) => {
+      if (rows.length === 0) {
+        return Promise.reject({ status: 404, msg: "Invalid ID" });
+      }
+      return rows[0];
+    });
+};
+
+module.exports = {
+  fetchCategories,
+  fetchReviewId,
+  fetchUsers,
+  patchReviewVotes,
+};


### PR DESCRIPTION
This pull request adds patch api/reviews/:review_id endpoint to increment votes of the specified ID. Moreover, it handles different errors mentioned below:

- If ID does not exist
- If ID is not an integer
- If the inc_vote key in object does not exist
- If the inc_vote value is not an integer 